### PR TITLE
Add --no-install-recommends

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM debian:stable-slim
 
 RUN apt-get update && apt-get -uy upgrade
-RUN apt-get -y install ca-certificates && update-ca-certificates
+RUN apt-get -y install --no-install-recommends ca-certificates \
+  && update-ca-certificates
 
 FROM scratch
 


### PR DESCRIPTION
Ca certificates recommends no packages to be updated. 
When running each build could fail to fetch the proper certificate
#1 

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
This PR would be helpful to maintain proper CA certificate without fetching the entire image packages to be build.

### 2. Which issues (if any) are related?
Image signature with certificates needs to be secured in an Enterprise environment with the smallest footprints as possible. 

### 3. Which documentation changes (if any) need to be made?
[https://docs.docker.com/docker-store/certify-images/#introduction](url)
[(https://packages.debian.org/search?keywords=ca-certificates)](url)
